### PR TITLE
Update kubernetes guide

### DIFF
--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -3,14 +3,14 @@
 :hazelcast: Hazelcast IMDG
 :framework: Kubernetes
 
-= External Hazelcast Client on Kubernetes
+= Connect To Hazelcast Running on Kubernetes from Outside
 
-This is a complete example presenting how to use Hazelcast cluster deployed on Kubernetes with Hazelcast Smart Client running outside of Kubernetes.
+This is a complete example presenting how to use Hazelcast cluster deployed on Kubernetes with Hazelcast Client running outside of Kubernetes.
 This example assumes you have a running Kubernetes cluster and the kubectl tool installed and configured.
 
 == What You’ll Learn
 
-In this guide you will learn how to deploy Hazelcast Kubernetes cluster and connect to it using external client.
+In this guide you will learn how to deploy Hazelcast Kubernetes cluster and connect to it using a client outside Kubernetes.
 
 == Prerequisites
 
@@ -166,7 +166,7 @@ Members {size:3, ver:3} [
 
 == Configure Hazelcast Client outside Kubernetes
 
-When we have a working Hazelcast cluster deployed on Kubernetes, we can connect to it with an external Hazelcast Smart Client. You need first to fetch the credentials of the created Service Account and then use them to configure the client.
+When we have a working Hazelcast cluster deployed on Kubernetes, we can connect to it with an external Hazelcast Client. You need first to fetch the credentials of the created Service Account and then use them to configure the client.
 
 === Check Kubernetes Master IP
 


### PR DESCRIPTION
Made a few small edits - first the name "external client" is a bit confusing and not quite obvious what the guide is about (it's not about client, it's about connecting to hazelcast). The guide title should have an objective and be action oriented rather than what it's about.
Also whether the client is smart or not, it's not so relevant for this guide - it's too much detail.