### PR TITLE
Enable UsePublicIP for the Go Client

### DIFF
--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -438,6 +438,7 @@ func main() {
 	config := hazelcast.Config{}
 	cc := &config.Cluster
 	cc.Network.SetAddresses("<EXTERNAL-IP>:5701")
+	cc.Discovery.UsePublicIP = true
 	ctx := context.TODO()
 	client, err := hazelcast.StartNewClientWithConfig(ctx, config)
 	if err != nil {


### PR DESCRIPTION
Although the smart routing example works as is on local, the following configuration is needed to tell the Go client to use public addresses:
```
config := hazelcast.Config{}
config.Cluster.Discovery.UsePublicIP = true
```
