### PR TITLE
Add missing `UsePublicIP` configs to doc & code samples

### DIFF
--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -164,6 +164,7 @@ func main() {
 	config := hazelcast.Config{}
 	cc := &config.Cluster
 	cc.Network.SetAddresses("<EXTERNAL-IP>:5701")
+	cc.Discovery.UsePublicIP = true
 	cc.Unisocket = true
 	ctx := context.TODO()
 	client, err := hazelcast.StartNewClientWithConfig(ctx, config)

--- a/go-unisocket/main.go
+++ b/go-unisocket/main.go
@@ -12,6 +12,7 @@ func main() {
 	config := hazelcast.Config{}
 	cc := &config.Cluster
 	cc.Network.SetAddresses("<EXTERNAL-IP>:5701")
+	cc.Discovery.UsePublicIP = true
 	cc.Unisocket = true
 	ctx := context.TODO()
 	client, err := hazelcast.StartNewClientWithConfig(ctx, config)

--- a/go/main.go
+++ b/go/main.go
@@ -12,6 +12,7 @@ func main() {
 	config := hazelcast.Config{}
 	cc := &config.Cluster
 	cc.Network.SetAddresses("<EXTERNAL-IP>:5701")
+	cc.Discovery.UsePublicIP = true
 	ctx := context.TODO()
 	client, err := hazelcast.StartNewClientWithConfig(ctx, config)
 	if err != nil {


### PR DESCRIPTION
In the Go client, it is required to set the `.Discovery.UsePublicIP`
to `true` to use external smart client discovery.