### PR TITLE
Force stdout to be unbuffered for Python tests

### DIFF
--- a/.github/workflows/integrational-tests.yml
+++ b/.github/workflows/integrational-tests.yml
@@ -138,7 +138,7 @@ jobs:
         cd python
         sed -i "s/<EXTERNAL-IP>/$EXTERNAL_IP/g" main.py
         pip install -r requirements.txt
-        python main.py >> output-python.txt &
+        python -u main.py >> output-python.txt &
         PID=$!
         sleep 30
         kill $PID


### PR DESCRIPTION
Looking at the logs, it seems that the client was able to connect
to cluster & discover remaining members using the public IPs, but
somehow the `grep` test failed. My gut feeling is that, `print`
statements in the script are buffered and not written the stdout
before we check and that caused the failure.

To solve this, we make the stdout unbuffered using `-u` option.
https://docs.python.org/3.8/using/cmdline.html#cmdoption-u