### PR TITLE
update metacontroller link url

### DIFF
--- a/docs/modules/ROOT/pages/kubernetes-external-client.adoc
+++ b/docs/modules/ROOT/pages/kubernetes-external-client.adoc
@@ -369,7 +369,7 @@ Helm and Metacontroller::
 --
 - Install Metacontroller plugin
 
-To install https://metacontroller.app/[Metacontroller] plugin, execute the following commands:
+To install https://github.com/metacontroller/metacontroller[Metacontroller] plugin, execute the following commands:
 
 [source, shell script]
 ----


### PR DESCRIPTION
Metacontroller link in the doc references to the wrong page.
I updated the link url as https://github.com/metacontroller/metacontroller